### PR TITLE
feat(redis): add Redis configuration with Lettuce and RedisTemplate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,12 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
+        <!-- Redis -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+
         <!-- Liquibase -->
         <dependency>
             <groupId>org.liquibase</groupId>

--- a/src/main/java/io/github/vitalii/userservice/config/RedisConfig.java
+++ b/src/main/java/io/github/vitalii/userservice/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package io.github.vitalii.userservice.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+        configuration.setPassword(password);
+        return new LettuceConnectionFactory(configuration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(LettuceConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,6 +23,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+      password: ${USER_SERVICE_REDIS_PASSWORD}
 
 logging:
   level:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,8 +17,9 @@ spring:
 
   data:
     redis:
-      host: prod-redis-host
+      host: localhost
       port: 6379
+      password: ${USER_SERVICE_REDIS_PASSWORD}
 
 logging:
   level:

--- a/src/test/java/io/github/vitalii/userservice/config/RedisConfigTest.java
+++ b/src/test/java/io/github/vitalii/userservice/config/RedisConfigTest.java
@@ -1,0 +1,46 @@
+package io.github.vitalii.userservice.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+
+@SpringBootTest(classes = RedisConfig.class)
+@TestPropertySource(properties = {
+        "spring.data.redis.host=localhost",
+        "spring.data.redis.port=6379",
+        "spring.data.redis.password=pass"
+})
+public class RedisConfigTest {
+
+    @Autowired
+    private LettuceConnectionFactory lettuceConnectionFactory;
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Test
+    void redisConnectionFactoryIsCreated() {
+        assertThat(lettuceConnectionFactory).isNotNull();
+        assertThat(lettuceConnectionFactory.getHostName()).isEqualTo("localhost");
+        assertThat(lettuceConnectionFactory.getPort()).isEqualTo(6379);
+        assertThat(lettuceConnectionFactory.getPassword()).isEqualTo("pass");
+    }
+
+    @Test
+    void redisTemplateIsConfiguredProperly() {
+        assertThat(redisTemplate).isNotNull();
+
+        assertThat(redisTemplate.getKeySerializer()).isInstanceOf(StringRedisSerializer.class);
+        assertThat(redisTemplate.getValueSerializer()).isInstanceOf(GenericJackson2JsonRedisSerializer.class);
+        assertThat(redisTemplate.getHashKeySerializer()).isInstanceOf(StringRedisSerializer.class);
+        assertThat(redisTemplate.getHashValueSerializer()).isInstanceOf(GenericJackson2JsonRedisSerializer.class);
+    }
+}
+


### PR DESCRIPTION
- implemented RedisConfig class with LettuceConnectionFactory bean using standalone config
- configured RedisTemplate with StringRedisSerializer for keys and GenericJackson2JsonRedisSerializer for values
- added unit tests for RedisConfig to verify bean creation and serializer settings
- updated application-dev.yml and application-prod.yml with Redis connection properties